### PR TITLE
vyatta-cfg: Fix memory leak in Cstore perl binding

### DIFF
--- a/perl_dmod/Cstore/Cstore.xs
+++ b/perl_dmod/Cstore/Cstore.xs
@@ -45,6 +45,10 @@ OUTPUT:
   RETVAL
 
 
+void
+Cstore::DESTROY()
+
+
 bool
 Cstore::cfgPathExists(CPATH *pref, bool active_cfg)
 PREINIT:

--- a/perl_dmod/Cstore/typemap
+++ b/perl_dmod/Cstore/typemap
@@ -12,7 +12,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-Cstore *      O_CPPOBJ
+Cstore *      O_OBJECT
 STRVEC *      T_STRVEC_REF
 CPATH *       T_CPATH_REF
 STRSTRMAP *   T_STRSTRMAP_REF
@@ -20,7 +20,7 @@ STRSTRMAP *   T_STRSTRMAP_REF
 
 ############################################################
 OUTPUT
-O_CPPOBJ
+O_OBJECT
   sv_setref_pv($arg, CLASS, (void *) $var);
 
 T_STRVEC_REF
@@ -44,7 +44,7 @@ T_STRSTRMAP_REF
 
 ############################################################
 INPUT
-O_CPPOBJ
+O_OBJECT
   if (sv_isobject($arg) && (SvTYPE(SvRV($arg)) == SVt_PVMG)) {
     $var = ($type) SvIV((SV *) SvRV($arg));
   } else {


### PR DESCRIPTION
The Cstore perl binding (XS) has memory leak bug.
This commit will fix this issue.

All XS should implement "DESTROY" function to free memory,
but this binding haven't this function.  It leads memory
leak each time when you call "new Cstore();" in perl code.

Additionally, VyOS Helium standard Perl module
"Vyatta::Config" have a Cstore instance variable, and each
time calling "new Vyatta::Config();" in Perl causes memory
leak due to this issue.  Especially, the long-live process
using Vyatta::Config (e.g. vyos-intfwatched) lead to serious
memory exhaustion problem due to this issue.

This patch implements the "DESTROY" function in XS for
Cstore library, and fix this memory leak issue.

I tested applying this patch for VyOS 1.1.8 release and
1.2.0 nightly (vyos-999.201801111542-amd64.iso).
Everythings looks fine in my environment.

NOTE: this commit will solve this issue:

* https://phabricator.vyos.net/T91