### PR TITLE
libboost-filesystem 1.62 is not compatible with jessie

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: contrib/net
 Priority: extra
 Maintainer: VyOS Package Maintainers <maintainers@vyos.net>
 Build-Depends: debhelper (>= 5), autotools-dev, libglib2.0-dev,
- libboost-filesystem-dev (>= 1.62), libapt-pkg-dev, libtool, flex,
+ libboost-filesystem-dev (>= 1.55), libapt-pkg-dev, libtool, flex,
  bison, libperl-dev, autoconf, automake, pkg-config, cpio, dh-autoreconf ,dh-systemd
 Standards-Version: 3.9.1
 


### PR DESCRIPTION
Updated build-depends to 1.55 as is shipped with jessie

Commit  f8cc921(https://github.com/vyos/vyatta-cfg/commit/f8cc92151e0c710c65da2089c9af70fd8cd230b5) breaks compiling on jessie because the version expected is newer than found on jessie.

prior to this commit version 1.55 was allowed.