### PR TITLE
T1134: libboost-filesystem 1.62 is not compatible with jessie

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: contrib/net
 Priority: extra
 Maintainer: VyOS Package Maintainers <maintainers@vyos.net>
 Build-Depends: debhelper (>= 5), autotools-dev, libglib2.0-dev,
- libboost-filesystem-dev (>= 1.62), libapt-pkg-dev, libtool, flex,
+ libboost-filesystem-dev (>= 1.55), libapt-pkg-dev, libtool, flex,
  bison, libperl-dev, autoconf, automake, pkg-config, cpio, dh-autoreconf ,dh-systemd
 Standards-Version: 3.9.1
 


### PR DESCRIPTION
Updated build-depends to 1.55 as is shipped with jessie

Commit f8cc921(f8cc921) breaks compiling on jessie because the version expected is newer than found on jessie.

prior to this commit version 1.55 was allowed.