### PR TITLE
T1068: Increase Max CMD Output

### DIFF
--- a/src/cstore/cstore.hpp
+++ b/src/cstore/cstore.hpp
@@ -84,7 +84,7 @@ public:
   static const string C_ENUM_SCRIPT_DIR;
   static const string C_LOGFILE_STDOUT;
 
-  static const size_t MAX_CMD_OUTPUT_SIZE = 4096;
+  static const size_t MAX_CMD_OUTPUT_SIZE = 40960;
 
   // for sorting
   /* apparently unordered_map template does not work with "enum" type, so


### PR DESCRIPTION
T1068: The 4096 character limit presented problems when creating large numbers of groups, which then needed to be called for autocomplete.
Increased by a factor of 10. Was then able to go from around 200 groups to well over 1000.