### PR TITLE
T1604: run bash builtin "set" as-is in vyatta_cfg_run

### DIFF
--- a/functions/interpreter/vyatta-cfg-run
+++ b/functions/interpreter/vyatta-cfg-run
@@ -509,6 +509,14 @@ vyatta_cfg_cmd ()
 ### Main run command ###
 vyatta_cfg_run ()
 {
+  # if run with bash builtin "set -/+*" run set and return
+  # this happens when a different completion script runs eval "set ..."
+  # (VyOS T1604)
+  if [[ "$1" == "set" && "$2" =~ ^(-|\+).* ]]; then
+    set "${@:2}"
+    return
+  fi
+
   # validate top level command and execute proper function
   local cmd=$1
   local -a args=( "$@" )


### PR DESCRIPTION
I tested this in a live system without building the package or ISO but I don't see why it wouldn't work.
There were some other files where the same error message is present in the code, but I couldn't figure out where or in what situation they're called or triggered so I left them alone (in any case, they're not triggered from the shell CLI):

https://github.com/vyos/vyatta-cfg/blob/06201c4e9ccb68341bebbf73acab74e6d51ab361/etc/bash_completion.d/vyatta-cfg#L809
  https://github.com/vyos/vyatta-cfg/blob/06201c4e9ccb68341bebbf73acab74e6d51ab361/src/cstore/cstore.cpp#L466
 https://github.com/vyos/vyatta-cfg/blob/06201c4e9ccb68341bebbf73acab74e6d51ab361/src/cstore/cstore.cpp#L2219
