### PR TITLE
T1970: init: delay initialization of vyos-router to udev is setteled

### DIFF
--- a/scripts/init/vyos-router
+++ b/scripts/init/vyos-router
@@ -173,6 +173,15 @@ bind_mount_boot ()
 
 start ()
 {
+    log_daemon_msg "Waiting for NIC's to settle down"
+    # On boot time udev migth take a long time to reorder nic's, this will ensure that
+    # all udev activity is completed and all nics presented at boot-time will have their
+    # final name before continuing with vyos-router initialization.
+    SECONDS=0
+    udevadm settle
+    STATUS=$?
+    log_progress_msg "setteled in ${SECONDS}sec."
+    log_end_msg ${STATUS}
     # Fixup for FRR
 
     # In 5.1 master, zebra thinks existence of /var/run/netns is


### PR DESCRIPTION
On devices with many nic's udev initialization and nic renaming could take a lot of time, this commit delays vyos-router startup  until udev is completed, and thouse all nic renaming processes are completed prior to starting vyos-router

Awaiting final test in T1970 before this is mergeable into current