### PR TITLE
Cloud-Init: T2117: Added order dependency for cloud-config.service

### DIFF
--- a/debian/vyatta-cfg.vyos-router.service
+++ b/debian/vyatta-cfg.vyos-router.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=VyOS Router
-After=systemd-journald-dev-log.socket time-sync.target local-fs.target
+After=systemd-journald-dev-log.socket time-sync.target local-fs.target cloud-config.service
 Conflicts=shutdown.target
 Before=systemd-user-sessions.service
 


### PR DESCRIPTION
As part of cleaning up our Cloud-Init package from changes incompatible with the upstream package, the `Before=vyos-router.service` should be moved from the `cloud-config.service` file to the `vyos-router.service` as `After=cloud-config.service`.
This should not affect anyhow the `vyos-router.service`, it will work as before in systems without Cloud-Init.
In systems with Cloud-Init package the `vyos-router.service` should be run after the `cloud-config.service`.