### PR TITLE
T3020: Correct scp completion hint

### DIFF
--- a/etc/bash_completion.d/vyatta-cfg
+++ b/etc/bash_completion.d/vyatta-cfg
@@ -198,7 +198,7 @@ vyatta_loadsave_complete()
       if [ "$command" = "load" ]; then
 	  echo -e "  <Enter>\t\t\t\t\tLoad from system config file"
 	  echo -e "  <file>\t\t\t\t\tLoad from file on local machine"
-	  echo -e "  scp://<user>[:<passwd>]@<host>/<file>\t\tLoad from file on remote machine"
+	  echo -e "  scp://<user>[:<passwd>]@<host>:/<file>\t\tLoad from file on remote machine"
 	  echo -e "  sftp://<user>[:<passwd>]@<host>/<file>\tLoad from file on remote machine"
 	  echo -e "  http://<host>/<file>\t\t\t\tLoad from file on remote machine"
 	  echo -e "  https://<host>/<file>\t\t\t\tLoad from file on remote machine"
@@ -206,7 +206,7 @@ vyatta_loadsave_complete()
 	  echo -e "  tftp://<host>/<file>\t\t\t\tLoad from file on remote machine"
       elif [ "$command" = "merge" ]; then
 	  echo -e "  <file>\t\t\t\t\tMerge from file on local machine"
-	  echo -e "  scp://<user>[:<passwd>]@<host>/<file>\t\tMerge from file on remote machine"
+	  echo -e "  scp://<user>[:<passwd>]@<host>:/<file>\t\tMerge from file on remote machine"
 	  echo -e "  sftp://<user>[:<passwd>]@<host>/<file>\tMerge from file on remote machine"
 	  echo -e "  http://<host>/<file>\t\t\t\tMerge from file on remote machine"
 	  echo -e "  https://<host>/<file>\t\t\t\tMerge from file on remote machine"
@@ -215,7 +215,7 @@ vyatta_loadsave_complete()
       elif [ "$command" = "save" ]; then
 	  echo -e "  <Enter>\t\t\t\tSave to system config file"
 	  echo -e "  <file>\t\t\t\tSave to file on local machine"
-	  echo -e "  scp://<user>:<passwd>@<host>/<file>\tSave to file on remote machine"
+	  echo -e "  scp://<user>:<passwd>@<host>:/<file>\tSave to file on remote machine"
 	  echo -e "  sftp://<user>:<passwd>@<host>/<file>\tSave to file on remote machine"
 	  echo -e "  ftp://<user>:<passwd>@<host>/<file>\tSave to file on remote machine"
 	  echo -e "  tftp://<host>/<file>\t\t\tSave to file on remote machine"
@@ -265,7 +265,7 @@ vyatta_loadkey_complete()
 	  echo
 	  echo "Possible completions:"
 	  echo -e "  <file>\t\t\t\tLoad from file on local machine"
-	  echo -e "  scp://<user>@<host>/<file>\tLoad from file on remote machine"
+	  echo -e "  scp://<user>@<host>:/<file>\tLoad from file on remote machine"
 	  echo -e "  sftp://<user>@<host>/<file>\tLoad from file on remote machine"
 	  echo -e "  ftp://<user>@<host>/<file>\tLoad from file on remote machine"
 	  echo -e "  http://<host>/<file>\t\t\tLoad from file on remote machine"


### PR DESCRIPTION
"scp" needs to get a ":" between the remote host and the remote
path. Let's reflect it in the completion order to avoid
confusion.

The doc has been updated with vyos/vyos-documentation#354