### PR TITLE
vyos-router: T3217: mount frr.conf to /run/frr/config dir

### DIFF
--- a/scripts/init/vyos-router
+++ b/scripts/init/vyos-router
@@ -253,6 +253,14 @@ start ()
     # a requirement for netns support
     mkdir -p /var/run/netns
 
+    # Fixup for FRR save configs T3217
+    mkdir -p /run/frr/config
+    echo "log syslog" > /run/frr/config/frr.conf
+    echo "log facility local7" >> /run/frr/config/frr.conf
+    chown -R root:frrvty /run/frr/config/frr.conf
+    chmod 775 /run/frr/config/frr.conf
+    mount --bind /run/frr/config/frr.conf /etc/frr/frr.conf
+
     # chown the config dir to give all admins access
     chown -R root:frrvty /etc/frr
     chmod 775 /etc/frr


### PR DESCRIPTION
Mount /run/frr/config/frr.conf to /etc/frr/frr.conf
It allows saving configurations when the system in operational mode.
So that config file do not persist between reboots.

For testing
Add any routing configuration
```
root@r4-roll:/home/vyos# vtysh -c "show run bgpd no-head"
Building configuration...

Current configuration:
!
frr version 7.5.1-20210324-01-ga912b1299
frr defaults traditional
hostname r4-roll
log syslog
log facility local7
service integrated-vtysh-config
!
router bgp 65001
 no bgp ebgp-requires-policy
 no bgp network import-check
 neighbor 203.0.113.2 remote-as 65003
!
line vty
!
end

```
Save configuration with
```sudo vtysh -n -w```

Kill routing daemon
```
root@r4-roll:/home/vyos# ps ax | grep bgpd
  795 ?        Ss     0:00 /usr/lib/frr/watchfrr -d -F traditional zebra bgpd ripd ripngd ospfd ospf6d isisd ldpd staticd bfdd
 1943 ?        Ssl    0:00 /usr/lib/frr/bgpd -d -F traditional --daemon -A 127.0.0.1 -M snmp -M rpki
 2088 pts/0    S+     0:00 grep bgpd
root@r4-roll:/home/vyos# 
root@r4-roll:/home/vyos# kill -9 1943
root@r4-roll:/home/vyos# 

```
Wait, the daemon is restarted by watchfrr.sh
re-check working daemon
```
root@r4-roll:/home/vyos# vtysh -c "show run bgpd no-head"
Building configuration...

Current configuration:
!
frr version 7.5.1-20210324-01-ga912b1299
frr defaults traditional
hostname r4-roll
log syslog
log facility local7
service integrated-vtysh-config
!
router bgp 65001
 no bgp ebgp-requires-policy
 no bgp network import-check
 neighbor 203.0.113.2 remote-as 65003
!
line vty
!
end
root@r4-roll:/home/vyos# 
```
