### PR TITLE
vyos-router: T3217: mount frr.conf to /run/frr/config

### DIFF
--- a/scripts/init/vyos-router
+++ b/scripts/init/vyos-router
@@ -190,6 +190,14 @@ start ()
     # a requirement for netns support
     mkdir -p /var/run/netns
 
+    # Fixup for FRR save configs T3217
+    mkdir -p /run/frr/config
+    echo "log syslog" > /run/frr/config/frr.conf
+    echo "log facility local7" >> /run/frr/config/frr.conf
+    chown -R root:frrvty /run/frr/config/frr.conf
+    chmod 775 /run/frr/config/frr.conf
+    mount --bind /run/frr/config/frr.conf /etc/frr/frr.conf
+
     # chown the config dir to give all admins access
     chown -R root:frrvty /etc/frr
     chmod 775 /etc/frr


### PR DESCRIPTION
Mount /run/frr/config/frr.conf to /etc/frr/frr.conf
It allows to saving configurations when the system in operational mode.
So that config file do not persist between reboots.

For testing
Add any routing configuration, save  and kill any routing daemon
```
set protocols bgp 65001 neighbor 203.0.113.3 remote-as '65001'
set protocols bgp 65001 neighbor 203.0.113.5 remote-as '65003'
set protocols bgp 65001 neighbor 203.0.113.8 remote-as '65002'
commit
sudo vtysh -n -w
```
Check daemon and kill it
```
vyos@r4-1.3:~$ ps ax | grep "frr/bgpd" | egrep -v grep
 5351 ?        Ssl    0:00 /usr/lib/frr/bgpd -d -F traditional --daemon -A 127.0.0.1 -M snmp -M rpki
vyos@r4-1.3:~$ 
vyos@r4-1.3:~$ sudo kill -9 5351
vyos@r4-1.3:~$ 

```
Show bgp after watchfrr restart the daemon
```
vyos@r4-1.3# run show ip bgp sum

IPv4 Unicast Summary:
BGP router identifier 192.168.122.14, local AS number 65001 vrf-id 0
BGP table version 0
RIB entries 0, using 0 bytes of memory
Peers 3, using 64 KiB of memory

Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd   PfxSnt
203.0.113.3     4      65001         0         0        0    0    0    never       Active        0
203.0.113.5     4      65003         0         0        0    0    0    never       Active        0
203.0.113.8     4      65002         0         0        0    0    0    never       Active        0
```

