### PR TITLE
scp-sftp: T3688: Add insecure option for curl save

### DIFF
--- a/scripts/vyatta-save-config.pl
+++ b/scripts/vyatta-save-config.pl
@@ -133,7 +133,7 @@ if ($mode eq 'url') {
             $host = $2;
         }
 
-        $rc = system("curl -u $user -# -T $url_tmp_file $save_file");
+        $rc = system("curl --insecure -u $user -# -T $url_tmp_file $save_file");
         if($rc >> 8 == 51){
             my $rsa_key = `ssh-keyscan -t rsa $host 2>/dev/null`;
             print "The authenticity of host '$host' can't be established.\n";


### PR DESCRIPTION
As workaround use option "insecure" for save via scp/sftp
https://phabricator.vyos.net/T3688

before fix:
```
vyos@r4-1.3# save scp://vyos:vyos@192.168.122.12:/
Saving configuration to 'scp://vyos:vyos@192.168.122.12:/'...

curl: (60) SSL peer certificate or SSH remote key was not OK
More details here: https://curl.haxx.se/docs/sslcerts.html

curl failed to verify the legitimacy of the server and therefore could not
establish a secure connection to it. To learn more about this situation and
how to fix it, please visit the web page mentioned above.
Error saving scp://vyos:vyos@192.168.122.12:/
[edit]
vyos@r4-1.3#

```
After fix:
```
vyos@r4-1.3# save scp://vyos:vyos@192.168.122.12:/home/vyos
Saving configuration to 'scp://vyos:vyos@192.168.122.12:/home/vyos'...

Done
[edit]
vyos@r4-1.3# 
```