### PR TITLE
interface-names: T3869: use vyos-interface-rescan instead of legacy

### DIFF
--- a/scripts/init/vyos-router
+++ b/scripts/init/vyos-router
@@ -182,8 +182,8 @@ clear_or_override_config_files ()
 
 update_interface_config ()
 {
-    if [ -d /run/udev/vyatta ]; then
-        $vyatta_sbindir/vyatta_interface_rescan /run/udev/vyatta $BOOTFILE
+    if [ -d /run/udev/vyos ]; then
+        $vyos_libexec_dir/vyos-interface-rescan.py $BOOTFILE
     fi
 }
 


### PR DESCRIPTION
Add support for https://github.com/vyos/vyos-1x/pull/1019 .