### PR TITLE
poweroff: T3888: correction of error message

### DIFF
--- a/functions/interpreter/vyatta-cfg-run
+++ b/functions/interpreter/vyatta-cfg-run
@@ -199,6 +199,11 @@ reboot ()
   echo "Exit from configure mode before rebooting."
 }
 
+poweroff ()
+{
+  echo "Exit from configure mode before shutting down."
+}
+
 vyatta_config_rollback ()
 {
   if [ $# != 1 ]; then


### PR DESCRIPTION
A proper message is added i.e. Exit from configure mode before shutting down.
 for the poweroff command when executed from the config mode.