### PR TITLE
firewall: T2199: Call firewall.py in vyos-router to create tables/chains

### DIFF
--- a/scripts/init/vyos-router
+++ b/scripts/init/vyos-router
@@ -282,6 +282,7 @@ start ()
     # As VyOS does not execute commands that are not present in the CLI we call
     # the script by hand to have a single source for the login banner and MOTD
     ${vyos_conf_scripts_dir}/system_console.py || log_failure_msg "could not reset serial console"
+    ${vyos_conf_scripts_dir}/firewall.py || log_failure_msg "could not initiate firewall rules"
     ${vyos_conf_scripts_dir}/system-login-banner.py || log_failure_msg "could not reset motd and issue files"
     ${vyos_conf_scripts_dir}/system-option.py || log_failure_msg "could not reset system option files"
     ${vyos_conf_scripts_dir}/conntrack.py || log_failure_msg "could not reset conntrack subsystem"


### PR DESCRIPTION
firewall.py needs to be run on boot to create the nft tables and chains expected before config is committed.

This PR will be required for the upcoming firewall PR on vyos-1x.