### PR TITLE
T1748: vbash: beautify tab completion output/line breaks

### DIFF
--- a/etc/bash_completion.d/vyatta-cfg
+++ b/etc/bash_completion.d/vyatta-cfg
@@ -463,11 +463,13 @@ get_help_text ()
       fi
     fi
     if [ ${#_get_help_text_items[idx]} -lt $((6 - $node)) ]; then
+      vyatta_help_text+="${_get_help_text_items[idx]}\\t\\t\\t"
+    elif [ ${#_get_help_text_items[idx]} -lt $((14 - $node)) ]; then
       vyatta_help_text+="${_get_help_text_items[idx]}\\t\\t"
-    elif [ ${#_get_help_text_items[idx]} -lt 13 ]; then
+    elif [ ${#_get_help_text_items[idx]} -lt 21 ]; then
       vyatta_help_text+="${_get_help_text_items[idx]}\\t"
     else
-      vyatta_help_text+="${_get_help_text_items[idx]}\\n\\x20\\x20\\x20\\t\\t"
+      vyatta_help_text+="${_get_help_text_items[idx]}\\n\\x20\\x20\\x20\\t\\t\\t"
     fi
     vyatta_help_text+="${_get_help_text_helps[idx]}"
   done


### PR DESCRIPTION
Change from

```
cpo@LR2.wue3# set service dhcp-server
Possible completions:
   disable      Temporary disable
   dynamic-dns-update
                Dynamically update Domain Name System (RFC4702)
 > failover     DHCP failover configuration
+  global-parameters
                Additional global parameters for DHCP server. You must
                use the syntax of dhcpd.conf in this text-field. Using this
                without proper knowledge may result in a crashed DHCP server.
                Check system log to look for errors.
   host-decl-name
                Use host declaration name for forward DNS name
   hostfile-update
                Updating /etc/hosts file (per client lease)
+  listen-address
                Local IPv4 addresses for service to listen on
+> shared-network-name
                Name of DHCP shared network
```

to

```
cpo@LR1.wue3# set service dhcp-server
Possible completions:
   disable              Disable instance
   dynamic-dns-update   Dynamically update Domain Name System (RFC4702)
 > failover             DHCP failover configuration
+  global-parameters    Additional global parameters for DHCP server. You must use the
                        syntax of dhcpd.conf in this text-field. Using this without
                        proper knowledge may result in a crashed DHCP server. Check
                        system log to look for errors.
   host-decl-name       Use host declaration name for forward DNS name
   hostfile-update      Updating /etc/hosts file (per client lease)
+  listen-address       Local IPv4 addresses to listen on
+> shared-network-name  Name of DHCP shared network
```

Also merge https://github.com/vyos/vyos-1x/pull/1366 after this one