### PR TITLE
T4607: Fallthrough to simple stream copy when Boost's copy_file fails

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+vyatta-cfg (0.102.0+vyos2+current5) unstable; urgency=medium
+
+  * Provide internal stream_copy fall-through for Boost's copy_file
+
+ -- Boris Lukashev <rageltman@sempervictus.com>  Sat, 13 Aug 2022 19:00:00 -0500
+
 vyatta-cfg (0.102.0+vyos2+current4) unstable; urgency=medium
 
   * Adjust for replacement of Quagga with FRR.


### PR DESCRIPTION
Kernel 5.15, and probably newer, present an EXEDEV error when the
vyatta-cfg code tries to boost::filesystem::copy_file on UnionFS
FUSE mounts. This completely breaks operation on newer kernels, and
is therefore a blocker to the rest of the project moving on to new
Linux LTS versions.

Boost is complex and fraught, this code behaves inconsistently in
verious operating environments, and can be a nightmare to debug.

Handle the concerns above using standard POSIX API in C++ to copy
the source to the destination if an exception occurs during the
existing Boost copy_file operation.

Testing:
  None yet, use at your own risk