### PR TITLE
cstore: T4664: add validation: no whitespace in tag node value names

### DIFF
--- a/src/cstore/cstore.hpp
+++ b/src/cstore/cstore.hpp
@@ -444,6 +444,10 @@ private:
   };
   // end path modifiers
 
+  // utility function
+  bool contains_whitespace(const char *name);
+  // end utility function
+
   // these require full path
   // (note: get_parsed_tmpl also uses current tmpl path)
   tr1::shared_ptr<Ctemplate> get_parsed_tmpl(const Cpath& path_comps,


### PR DESCRIPTION
Add global validation within cstore to reject whitespace in tag node value names.

How to test:
One wants to test on a tag node without explicit value validation that would otherwise rule out whitespace, so either one can check "... authentication public-keys", which was the site of the original bug report, or one can use the skeleton interface definition and conf-mode script here:

https://github.com/jestabro/vyos-1x/blob/test-tag-node-value-name-whitespace/interface-definitions/simple.xml.in
https://github.com/jestabro/vyos-1x/blob/test-tag-node-value-name-whitespace/src/conf_mode/simple.py