### PR TITLE
T4922: T2651: clean ssh-client and cURL configs on boot

### DIFF
--- a/scripts/init/vyos-router
+++ b/scripts/init/vyos-router
@@ -180,6 +180,10 @@ security_reset ()
 {
     # Container
     rm -f /etc/containers/storage.conf /etc/containers/registries.conf
+
+    # System Options (SSH/cURL)
+    rm -f /etc/ssh/ssh_config.d/*vyos*.conf
+    rm -f /etc/curlrc
 }
 
 # XXX: T3885 - generate persistend DHCPv6 DUID (Type4 - UUID based)


### PR DESCRIPTION
(cherry picked from commit 4448d944c3cb6a47692119c8f1e8442e82316183)

This belongs to https://github.com/vyos/vyos-1x/pull/1743 and must be merged accordingly