### PR TITLE
loadkey: T3506: Remove (what remains of) loadkey

### DIFF
--- a/etc/bash_completion.d/vyatta-cfg
+++ b/etc/bash_completion.d/vyatta-cfg
@@ -230,19 +230,6 @@ vyatta_loadsave_complete()
   eval $restore_shopts
 }
 
-vyatta_config_loadkey()
-{
-    echo "Warning: The obsolete 'loadkey' command has been phased out."
-    echo "Instead, use the op-mode command 'generate public-key-command' to generate commands for manual addition:"
-    echo '$ generate public-key-command name <username> path <path-or-url>'
-    echo
-}
-
-vyatta_loadkey_complete()
-{
-    true
-}
-
 print_commit_log ()
 {
   local -a array

--- a/functions/interpreter/vyatta-cfg-run
+++ b/functions/interpreter/vyatta-cfg-run
@@ -34,7 +34,6 @@ _vyatta_cfg_cmds=( "confirm" \
                    "edit" \
                    "exit" \
                    "load" \
-                   "loadkey" \
                    "merge" \
                    "rename" \
                    "rollback" \
@@ -54,7 +53,6 @@ _vyatta_cfg_helps=( \
       "Edit a sub-element" \
       "Exit from this configuration level" \
       "Load configuration from a file and replace running configuration" \
-      "Load user SSH key from a file" \
       "Load configuration from a file and merge running configuration" \
       "Rename a configuration element" \
       "Rollback to a prior config revision (requires reboot)" \
@@ -570,7 +568,6 @@ vyatta_cfg_run ()
     compare) vyatta_config_compare "${@:2}";;
     save) vyatta_config_save "${@:2}" ;;
     merge) vyatta_config_merge "${@:2}" ;;
-    loadkey) vyatta_config_loadkey "${@:2}";;
     *) vyatta_cfg_cmd $fcmd "${@:2}" ;; # commands requiring path expansion must go through here
   esac
 }
@@ -612,8 +609,6 @@ _vyatta_cfg_init ()
                complete -F vyatta_single_word_complete ${cmd:0:$pos} ;; 
             run)
               complete -F vyatta_run_complete ${cmd:0:$pos} ;;
-            loadkey)
-              complete -F vyatta_loadkey_complete ${cmd:0:$pos} ;;
             compare)
               complete -F vyatta_compare_complete ${cmd:0:$pos} ;;
             rollback)


### PR DESCRIPTION
It's been ten months since `loadkey` was deprecated and I think we can remove the deprecation notice from 1.4 as part of the effort to thin down what remains of legacy Vyatta code.
https://phabricator.vyos.net/T3506