### PR TITLE
cstore: T4664: add validation: no whitespace in tag node value names (backport)

### DIFF
--- a/src/cstore/cstore.hpp
+++ b/src/cstore/cstore.hpp
@@ -444,6 +444,10 @@ private:
   };
   // end path modifiers
 
+  // utility function
+  bool contains_whitespace(const char *name);
+  // end utility function
+
   // these require full path
   // (note: get_parsed_tmpl also uses current tmpl path)
   tr1::shared_ptr<Ctemplate> get_parsed_tmpl(const Cpath& path_comps,


### PR DESCRIPTION
(cherry picked from commit 3f407aa8d66dacbbf92e22673d8871e429079ce0)