### PR TITLE
commit: T4990: call sync after the commit completes

### DIFF
--- a/src/commit/commit-algorithm.cpp
+++ b/src/commit/commit-algorithm.cpp
@@ -14,6 +14,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <unistd.h>
+
 #include <cstdio>
 #include <vector>
 #include <string>
@@ -1357,6 +1359,8 @@ commit::doCommit(Cstore& cs, CfgNode& cfg1, CfgNode& cfg2)
   if (ret) {
     ret = cs.markSessionUnsaved();
   }
+
+  sync();
 
   setenv("COMMIT_STATUS", cst, 1);
   _execute_hooks(POST_COMMIT);


### PR DESCRIPTION
This ensures that filesystem buffers are flushed even if post-commit hooks fail to run for some reason.