### PR TITLE
Docker: T5076: add script to install dependencies and build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,4 +20,5 @@
 @Library('vyos-build@current')_
 
 // Start package build using library function from https://github.com/vyos/vyos-build
-buildPackage(null, null, null, true)
+def buildCmd = './build.sh'
+buildPackage(null, null, buildCmd, true)

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e
+
+echo "I: Install dependencies"
+sudo apt install -y libglib2.0-dev libboost-filesystem-dev libperl-dev
+
+echo "I: Build Debian Package"
+dpkg-buildpackage -uc -us -tc -b


### PR DESCRIPTION
Following T5076, add script to install dependencies and run build command. The change to the Jenkinsfile has not been tested in CI, yet. Pending PRs for vyatta-cfg will need this in place before merging.