### PR TITLE
T5291: vyatta-cfg-cmd-wrapper missing ${vyos_libexec_dir} variable

### DIFF
--- a/scripts/vyatta-cfg-cmd-wrapper
+++ b/scripts/vyatta-cfg-cmd-wrapper
@@ -25,6 +25,7 @@
 # some env variables are needed
 export vyatta_sysconfdir=/opt/vyatta/etc
 export vyatta_sbindir=/opt/vyatta/sbin
+export vyos_libexec_dir=/usr/libexec/vyos
 
 LOGFILE=/var/log/vyatta/vyatta-commit.log
 


### PR DESCRIPTION
In file: /opt/vyatta/sbin/vyatta-cfg-cmd-wrapper

Commit 9e74ad7 changed the vyos-load-config.py script directory prefix to use ${vyos_libexec_dir}. However, the ${vyos_libexec_dir} variable is not exported at the start of the wrapper script.

When executing the load command over an SSH session it tries to execute the vyos-load-config.py script from root, and not /usr/libexec/vyos where the script resides

and this code tested in https://vyos.dev/T5291

Found error and tested by https://vyos.dev/p/sjcarr/