### PR TITLE
T775: Add postcommit-hooks in run directory

### DIFF
--- a/scripts/vyos-user-postcommit-hooks.sh
+++ b/scripts/vyos-user-postcommit-hooks.sh
@@ -3,3 +3,8 @@
 if [ -d /config/scripts/commit/post-hooks.d/ ]; then
     sg vyattacfg -c "/bin/run-parts /config/scripts/commit/post-hooks.d"
 fi
+
+# T775 Add commit post-hook for /run
+if [ -d /run/scripts/commit/post-hooks.d/ ]; then
+    sg vyattacfg -c "/bin/run-parts /run/scripts/commit/post-hooks.d"
+fi


### PR DESCRIPTION
Use `/run/scripts/commit/post-hooks.d` directory for scripts generated by `set service config-sync`

## Task

   * https://vyos.dev/T775


## Related PR
https://github.com/vyos/vyos-1x/pull/2042