### PR TITLE
configdep: T5660: add marker for last element of priority queues

### DIFF
--- a/src/cli_cstore.h
+++ b/src/cli_cstore.h
@@ -142,6 +142,8 @@ int restore_output(void);
 /* functions from cli_objects */
 char *get_at_string(void);
 void set_in_commit(boolean b);
+void set_if_last(int);
+void clear_last(void);
 void set_at_string(char* s);
 void set_in_delete_action(boolean b);
 

--- a/src/cli_objects.c
+++ b/src/cli_objects.c
@@ -34,6 +34,7 @@ static first_seg f_seg_m;
 
 static char *in_commit_file = "/var/tmp/in_commit";
 static char *initial_file = "/var/tmp/initial_in_commit";
+static char *last_in_queue_file = "/var/tmp/last_in_queue";
 
 static int mark_by_file(char *p) {
     int ret = mknod(p, S_IFREG|0664, 0);
@@ -94,6 +95,16 @@ void set_in_commit(boolean b) {
   } else {
       remove_mark(in_commit_file);
   }
+}
+
+void set_if_last(int n) {
+  if (n == 1) {
+    mark_by_file(last_in_queue_file);
+  }
+}
+
+void clear_last(void) {
+  remove_mark(last_in_queue_file);
 }
 
 boolean is_in_exec(void) {

--- a/src/commit/commit-algorithm.cpp
+++ b/src/commit/commit-algorithm.cpp
@@ -1306,8 +1306,11 @@ commit::doCommit(Cstore& cs, CfgNode& cfg1, CfgNode& cfg2)
 
   debug_on = !!getenv("VYOS_DEBUG");
   TRACE_INIT("Processing the Priority Queue");
+  clear_last();
+  int num = pq.size();
   while (!dpq.empty()) {
     PrioNode *p = dpq.top();
+    set_if_last(num+dpq.size());
     if (!_commit_exec_prio_subtree(cs, p)) {
       // prio subtree failed
       OUTPUT_USER("delete [ %s ] failed\n", 
@@ -1321,6 +1324,7 @@ commit::doCommit(Cstore& cs, CfgNode& cfg1, CfgNode& cfg2)
   }
   while (!pq.empty()) {
     PrioNode *p = pq.top();
+    set_if_last(pq.size());
     if (!_commit_exec_prio_subtree(cs, p)) {
       // prio subtree failed
       OUTPUT_USER("[[%s]] failed\n",


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Add support for
https://github.com/vyos/vyos-1x/pull/2659
configdep: T5660: remove global redundancies under vyos-configd

If vyos-configd is to maintain the global list of config dependencies, it needs to know when the last exec of the priority queue is called, in order to then execute the list of config dependency scripts.


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5660

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
https://github.com/vyos/vyos-1x/pull/2659
## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
