### PR TITLE
T6088: Fix saving confiugration and replacing fsync with sync

### DIFF
--- a/scripts/vyatta-save-config.pl
+++ b/scripts/vyatta-save-config.pl
@@ -22,7 +22,7 @@
 use strict;
 use lib "/opt/vyatta/share/perl5";
 use Vyatta::ConfigOutput;
-use File::Sync qw(fsync);
+use File::Sync qw(sync);
 use FileHandle;
 use IO::Prompt;
 use Vyatta::Misc qw(get_short_config_path);
@@ -118,8 +118,8 @@ close($show_fd);
 print $version_str;
 select STDOUT;
 
-fsync $save;
 close $save;
+sync();
 
 if ($mode eq 'url') {
     system("python3 -c 'from vyos.remote import upload; upload(\"$url_tmp_file\", \"$save_file\")'");


### PR DESCRIPTION
The `fsync` function does not work correctly and if we force reset the system (sysrq-trigger to emulate power cut) or do "power cut" on the baremetal server immediately after saving, we will get the corrupted configuration file `/config/config.boot`

Using `sync` fixes this bug

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T6088

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
save, config.boot
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
To reproduce:
### Step01
```
echo 1 | sudo tee /proc/sys/kernel/sysrq
set protocols static route 192.0.2.5/32 blackhole
commit
```
### Step02
Add script:
```
cat /config/scripts/myscript.sh
#!/bin/vbash
source /opt/vyatta/etc/functions/script-template
configure
delete protocols static route 192.0.2.5/32
commit
set protocols static route 192.0.2.5/32 dhcp-interface eth2
commit
save
exit
```
### Step3
Execute the script, waiting for the message `Saving configuration to '/config/config.boot'...Done`
And immediately force a reboot or powercut the instance.
```
vyos@r15-left# sudo sg vyattacfg -c /config/scripts/myscript.sh
Saving configuration to '/config/config.boot'...
Done
[edit]
vyos@r15-left# echo b | sudo tee /proc/sysrq-trigger
b
```
Before the fix, after reboot we have corrupted config
![config-fails](https://github.com/vyos/vyatta-cfg/assets/12792111/977f2dfb-8932-47b7-9970-e8d5209378d5)

After the fix the system boots properly


## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
