### PR TITLE
configdep: T6206 fix marker for last element of delete priority queues

### DIFF
--- a/src/commit/commit-algorithm.cpp
+++ b/src/commit/commit-algorithm.cpp
@@ -1308,6 +1308,8 @@ commit::doCommit(Cstore& cs, CfgNode& cfg1, CfgNode& cfg2)
   TRACE_INIT("Processing the Priority Queue");
   clear_last();
   int num = pq.size();
+  // decrease by one because we have one root element
+  --num;
   while (!dpq.empty()) {
     PrioNode *p = dpq.top();
     set_if_last(num+dpq.size());


### PR DESCRIPTION
related task: T5660: add marker for last element of priority queues

Problem: In the priority queue we always have one empty root element after `_get_commit_prio_queue` therefore minimum length is 1 and we can't mark as last any deleted node, even when we try to delete only one node e.g. `del vpn`
also when we try to add\change one node, in the queue we have two element: one empty and one that we use.

This root element has state as `COMMIT_STATE_UNCHANGED` probably will be better to filter this element in `_get_commit_prio_queue` but i don't know how it affect feature not related with configdep.
also, all other unchanged nodes filtered before `doCommit`.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6206
* https://vyos.dev/T5660
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
/usr/libexec/vyos/tests/smoke/cli/test_vpn_l2tp.py
```
or try to delete node with a dependency e.g `del vpn l2tp`

```
set interfaces dummy dum0 address 203.0.113.1/32
set vpn ipsec interface dum0
commit
sudo -S swanctl -L

set vpn l2tp remote-access authentication local-users username foo password bar
set vpn l2tp remote-access authentication mode local
set vpn l2tp remote-access authentication protocols chap
set vpn l2tp remote-access client-ip-pool first range 10.200.100.100-10.200.100.110
set vpn l2tp remote-access description VPN - REMOTE
set vpn l2tp remote-access name-server 1.1.1.1
set vpn l2tp remote-access ipsec-settings authentication mode pre-shared-secret
set vpn l2tp remote-access ipsec-settings authentication pre-shared-secret SeCret
set vpn l2tp remote-access ipsec-settings ike-lifetime 8600
set vpn l2tp remote-access ipsec-settings lifetime 3600
set vpn l2tp remote-access outside-address 203.0.113.1
set vpn l2tp remote-access gateway-address 203.0.113.1
commit
sudo -S swanctl -L

del vpn l2tp
commit

sudo -S swanctl -L

```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
