### PR TITLE
cli: T6383: improve completion help for rollback commands

### DIFF
--- a/etc/bash_completion.d/vyatta-cfg
+++ b/etc/bash_completion.d/vyatta-cfg
@@ -253,7 +253,40 @@ vyatta_rollback_complete ()
   if [ $COMP_CWORD -eq 1 -a -z "${COMP_WORDS[1]}" ]; then
       echo
       echo "Possible completions:"
-      echo -e "  <N>\tRollback to revision N (currently requires reboot)"
+      echo -e "  <N>\tRollback to revision N (requires reboot)"
+      echo -e "     \t(use rollback-soft for a non-disruptive rollback)
+      echo -e "\n  Revisions:"
+      print_commit_log
+      COMPREPLY=( "" " " )
+  else
+      echo -en "\nPossible completions:\n"
+      echo -en "  <Enter>\tExecute the current command"
+      COMPREPLY=( "" " " )
+  fi
+
+  eval $restore_shopts
+}
+
+vyatta_rollback-soft_complete ()
+{
+  # Generate completion help for the "rollback-soft" command
+
+  local restore_shopts=$( shopt -p extglob nullglob | tr \\n \; )
+  shopt -s extglob nullglob
+
+  if [[ $COMP_CWORD -eq 0 ]];then
+    vyatta_config_complete "$@"
+    eval $restore_shopts
+    return
+  fi
+
+  # Only provide completions after command name has been typed, but
+  # before any characters of the command argument have been entered.
+  if [ $COMP_CWORD -eq 1 -a -z "${COMP_WORDS[1]}" ]; then
+      echo
+      echo "Possible completions:"
+      echo -e "  <N>\tRollback to revision N"
+      echo -e "     \t(applies a diff that you can compare and commit)"
       echo -e "\n  Revisions:"
       print_commit_log
       COMPREPLY=( "" " " )

--- a/functions/interpreter/vyatta-cfg-run
+++ b/functions/interpreter/vyatta-cfg-run
@@ -627,7 +627,7 @@ _vyatta_cfg_init ()
             rollback)
               complete -F vyatta_rollback_complete ${cmd:0:$pos} ;;
             rollback-soft)
-              complete -F vyatta_rollback_complete ${cmd:0:$pos} ;;
+              complete -F vyatta_rollback-soft_complete ${cmd:0:$pos} ;;
             commit|commit-confirm)
                complete -F vyatta_commit_complete ${cmd:0:$pos} ;;
             *)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Add informative completion help for `rollback-soft` and add a hint to use `rollback-soft` to the completion help of the old rollback. 

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): help string improvement.

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
