### PR TITLE
T7374: allow use of exisiting vyconf replacements for my_* commands

### DIFF
--- a/functions/interpreter/vyatta-cfg-run
+++ b/functions/interpreter/vyatta-cfg-run
@@ -103,9 +103,17 @@ vyatta_config_show ()
 
 vyatta_config_commit ()
 {
-  if ! vyatta_cli_shell_api sessionChanged; then
-    echo "No configuration changes to commit"
-    return 1;
+  if test -f "/var/run/vyconf_backend"; then
+    echo $$
+    if ! /usr/libexec/vyos/vyconf/bin/vy_session_changed; then
+      echo "No configuration changes to commit"
+      return 1;
+    fi
+  else
+    if ! vyatta_cli_shell_api sessionChanged; then
+      echo "No configuration changes to commit"
+      return 1;
+    fi
   fi
   local comment="commit"
   local next=0
@@ -126,16 +134,28 @@ vyatta_config_commit ()
 
   export COMMIT_COMMENT="$comment"
   export COMMIT_VIA=cli
-  /opt/vyatta/sbin/my_commit "${args[@]}" 2>&1
+  if test -f "/var/run/vyconf_backend"; then
+    /usr/libexec/vyos/vyconf/bin/vy_commit "${args[@]}" 2>&1
+  else
+    /opt/vyatta/sbin/my_commit "${args[@]}" 2>&1
+  fi
   unset COMMIT_VIA
   unset COMMIT_COMMENT
 }
 
 vyatta_config_commit-confirm ()
 {
-  if ! vyatta_cli_shell_api sessionChanged; then
-    echo "No configuration changes to commit"
-    return 1;
+  if test -f "/var/run/vyconf_backend"; then
+    echo $$
+    if ! /usr/libexec/vyos/vyconf/bin/vy_session_changed; then
+      echo "No configuration changes to commit"
+      return 1;
+    fi
+  else
+    if ! vyatta_cli_shell_api sessionChanged; then
+      echo "No configuration changes to commit"
+      return 1;
+    fi
   fi
   local -a args=()
   local first=1
@@ -358,7 +378,11 @@ vyatta_cfg_cmd_run ()
     elif [[ "$cmd" == "show" ]]; then 
       vyatta_config_show "${@:2}"
     else 
-      cmd="/opt/vyatta/sbin/my_$cmd"
+      if test -f "/var/run/vyconf_backend"; then
+        cmd="${vyconf_bin_dir}/vy_$cmd"
+      else
+        cmd="/opt/vyatta/sbin/my_$cmd"
+      fi
       output=$($cmd "${@:2}")
     fi   
     vyatta_cfg_print_output "$output"


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

This requires merge of PRs:
https://github.com/vyos/vyconf/pull/23
https://github.com/vyos/libvyosconfig/pull/40
https://github.com/vyos/vyos-1x/pull/4526

Conditionally call `vy_*` replacements for certain `my_*` commands, notably `my_set` and `my_commit`.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
https://github.com/vyos/vyconf/pull/23
https://github.com/vyos/libvyosconfig/pull/40
https://github.com/vyos/vyos-1x/pull/4526
## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
