### PR TITLE
cli: T6769: check commit arguments

### DIFF
--- a/functions/interpreter/vyatta-cfg-run
+++ b/functions/interpreter/vyatta-cfg-run
@@ -116,13 +116,14 @@ vyatta_config_commit ()
     fi
   fi
 
+  local comment="commit"
   if [ $# -gt 0 ] ; then
     if [ $# = 1 ] || [ $# -gt 2 ] || [ "$1" != "comment" ]; then
       if [ "$1" == "confirm" ]; then
         echo "Use commit-confirm command"
         return 1
       fi
-      echo "Error: commit accepts either no arugments, or optional 'comment'" \
+      echo "Error: commit accepts either no arguments, or optional 'comment'" \
            "with comment text as second argument."
       echo -e "\tUsage: 'commit [comment COMMENTTEXT]'"
       return 1;

--- a/functions/interpreter/vyatta-cfg-run
+++ b/functions/interpreter/vyatta-cfg-run
@@ -115,29 +115,27 @@ vyatta_config_commit ()
       return 1;
     fi
   fi
-  local comment="commit"
-  local next=0
-  local -a args=()
-  for arg in "$@"; do
-    if [ "$next" == "1" ]; then
-      comment=$arg
-      next=0;
-    elif [ "$arg" == "comment" ]; then
-      next=1
-    elif [ "$arg" == "confirm" ]; then
-      echo Use commit-confirm command
+
+  if [ $# -gt 0 ] ; then
+    if [ $# = 1 ] || [ $# -gt 2 ] || [ "$1" != "comment" ]; then
+      if [ "$1" == "confirm" ]; then
+        echo "Use commit-confirm command"
+        return 1
+      fi
+      echo "Error: commit accepts either no arugments, or optional 'comment'" \
+           "with comment text as second argument."
+      echo -e "\tUsage: 'commit [comment COMMENTTEXT]'"
       return 1;
-    else
-      args[${#args[@]}]="$arg"    
     fi
-  done
+    comment="$2"
+  fi
 
   export COMMIT_COMMENT="$comment"
   export COMMIT_VIA=cli
   if test -f "/var/run/vyconf_backend"; then
-    /usr/libexec/vyos/vyconf/bin/vy_commit "${args[@]}" 2>&1
+    /usr/libexec/vyos/vyconf/bin/vy_commit 2>&1
   else
-    /opt/vyatta/sbin/my_commit "${args[@]}" 2>&1
+    /opt/vyatta/sbin/my_commit 2>&1
   fi
   unset COMMIT_VIA
   unset COMMIT_COMMENT


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Check arguments of `commit` command

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Related Task(s)
https://vyos.dev/T6769

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes

Validate `commit` command arguments according to https://vyos.dev/T6769.

Here is detailed commit message:

Check usage: `commit [comment COMMENTTEXT]`

Make any other option combination an error and don't
pass other arguments to inner scripts.

Before this commit command `commit` silently accepted any
number of arguments, moreover given
`spam1 comment hi1 spam2 comment hi2 spam3`
parsing script silently ignored first `comment hi1`, has written
`hi2` as comment and passed `spam1 spam2 spam3` to inner script.

There are two options for inner scripts:

/opt/vyatta/sbin/my_commit
    Code in vyatta-cfg/src/cli_bin.cpp$
    argv is used to check script name and passed to doCommit which ignores it

/usr/libexec/vyos/vyconf/bin/vy_commit
    vyos-1x/python/vyos/vyconf_session.py
    In similar way argv is used to determine script name

Both don't use any arguments, so passing and collecting other arguments
seems not needed and confusing

Open questions:

1. It seems that /opt/vyatta/sbin/my_commit doesn't use COMMIT_COMMENT. Should it be an error to try to use comment with it?
2. Maybe I missed something and passing of other parameters is useful?.. What should be validated then?..
3. Maybe I should change error message?

## How to test

Run VyOS (I've used docker image generated from manually built ISO accodring to https://docs.vyos.io/en/latest/installation/virtual/docker.html[])

Rebuild and install this package (`vyatta-cfg`) according to https://docs.vyos.io/en/latest/contributing/build-vyos.html#build-packages

Inside VyOS docker run:

```
$ configure
# set service ssh port '22'
# commit some wrong arguments
# commit confirm
# commit comment
# commit comment too many arguments
# commit comment "Correct usage at last"
```

`commit confirm` gives (as was before this commit):

```
commit confirm
```

Each other wrong try gives:
```
Error: commit accepts either no arugments, or optional 'comment' with comment text as second argument.
        Usage: 'commit [comment COMMENTTEXT]'
```

Also `commit` without arguments was checked.


## Smoketest result

It seems there is no smoke test that launches commit from sommand line.
I've just lauched random one: `/usr/libexec/vyos/tests/smoke/cli/test_nat.py`
It runs without problems.

If I need to run all tests/write specific test to test this changes, please write.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
