### PR TITLE
cli: T6769: fix after commit args validation

### DIFF
--- a/functions/interpreter/vyatta-cfg-run
+++ b/functions/interpreter/vyatta-cfg-run
@@ -176,7 +176,7 @@ vyatta_config_commit-confirm ()
   eval "sudo sg vyattacfg \"$cmd\" "
   if [ $? = 0 ]; then
     export IN_COMMIT_CONFIRM=t
-    vyatta_config_commit "$@"
+    vyatta_config_commit "${args[@]}"
     unset IN_COMMIT_CONFIRM
   fi
 }


### PR DESCRIPTION
## Fix commit-config after commit validation

Command `commit-config` passed all it's arguments
to `commit`. This led to an error in case of simple usage `commit-config 1`: "1" was passed to commit and validation rejected this argument.


## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Related Task(s)

* https://vyos.dev/T6769

## Related PR(s)

https://github.com/vyos/vyatta-cfg/pull/103

## Component(s) name

* cli

## Proposed changes

Fix is just to use `args` variable instead that was already calculated in function and filtered out first numerical argument, but wasn't used.

## How to test

Run `commit-confirm 1` after any configuration change.

Before fix validation error will appear as 1 is passed to commit.

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
