### PR TITLE
T8061: use vyconf compatible calls for completion data

### DIFF
--- a/etc/bash_completion.d/vyatta-cfg
+++ b/etc/bash_completion.d/vyatta-cfg
@@ -489,7 +489,11 @@ get_help_text ()
       vyatta_help_text+="\\x20\\x20"
     else
       if [[ $print_node_type -ne 0 ]]; then
-        local nodeType=$(cli-shell-api getNodeType ${editlvl} ${api_args[@]:1:$[${comp_cword}-1]} "${_get_help_text_items[idx]}")
+        if test -f "/var/run/vyconf_backend"; then
+          local nodeType=$(${vyconf_bin_dir}/vyconf_cli_compat getNodeType ${editlvl} ${api_args[@]:1:$[${comp_cword}-1]} "${_get_help_text_items[idx]}")
+        else
+          local nodeType=$(cli-shell-api getNodeType ${editlvl} ${api_args[@]:1:$[${comp_cword}-1]} "${_get_help_text_items[idx]}")
+        fi
         case  "$nodeType" in
           tag) vyatta_help_text+="+> " ;;
           non-leaf) vyatta_help_text+=" > " ;;
@@ -777,7 +781,11 @@ vyatta_config_expand_compwords ()
         else
             path=( "${expanded_api_args[@]}" "$arg" )
         fi
-        vyatta_cli_shell_api getCompletionEnv "${path[@]}"
+        if test -f "/var/run/vyconf_backend"; then
+          vyos_cli_shell_api getCompletionEnv "${path[@]}"
+        else
+          vyatta_cli_shell_api getCompletionEnv "${path[@]}"
+        fi
         if [[ "${#_cli_shell_api_comp_values[@]}" == "1" ]]; then
           if [[ "$_cli_shell_api_last_comp_val" == 'true' ]]; then
             arg=$arg
@@ -804,7 +812,11 @@ vyatta_config_invalid_comp ()
   local path=''
   local opath=''
   local failed=false
-  local validate="cli-shell-api validateTmplPath -- $editlvl"
+  if test -f "/var/run/vyconf_backend"; then
+    local validate="${vyconf_bin_dir}/vyconf_cli_compat validateTmplPath $editlvl"
+  else
+    local validate="cli-shell-api validateTmplPath -- $editlvl"
+  fi
   for elem in "${expanded_api_args[@]:1}"; do
     if [[ -z "$elem" ]]; then
       continue
@@ -827,34 +839,66 @@ vyatta_config_invalid_comp ()
       else
         path="$path $arg"
       fi
-      if ! cli-shell-api validateTmplPath -- ${editlvl} ${path}; then
-        _cli_shell_api_comp_values=()
-        vyatta_cli_shell_api getCompletionEnv $cmd ${path}
-        if [[ "${#_cli_shell_api_comp_values[@]}" != "1"
-           && "${#_cli_shell_api_comp_values[@]}" != "0" ]]; then
-          local -a _get_help_text_items=( "${_cli_shell_api_hitems[@]}" )
-          local -a _get_help_text_helps=( "${_cli_shell_api_hstrs[@]}" )
-          local vyatta_help_text=''
-          if [[ $opath == '' ]]; then
-            echo -ne "\n\n  Configuration path: [$arg] is ambiguous\n"
+      if test -f "/var/run/vyconf_backend"; then
+        if ! ${vyconf_bin_dir}/vyconf_cli_compat validateTmplPath ${editlvl} ${path}; then
+          _cli_shell_api_comp_values=()
+          vyos_cli_shell_api getCompletionEnv $cmd ${path}
+          if [[ "${#_cli_shell_api_comp_values[@]}" != "1"
+             && "${#_cli_shell_api_comp_values[@]}" != "0" ]]; then
+            local -a _get_help_text_items=( "${_cli_shell_api_hitems[@]}" )
+            local -a _get_help_text_helps=( "${_cli_shell_api_hstrs[@]}" )
+            local vyatta_help_text=''
+            if [[ $opath == '' ]]; then
+              echo -ne "\n\n  Configuration path: [$arg] is ambiguous\n"
+            else
+              echo -ne "\n\n  Configuration path: $opath [$arg] is ambiguous\n"
+            fi
+            get_help_text 0
+            echo -ne "$vyatta_help_text\n" | sed 's/^P/  P/'
+            failed=true
+            break
           else
-            echo -ne "\n\n  Configuration path: $opath [$arg] is ambiguous\n"
+            if [[ $opath == '' ]]; then
+              echo -ne "\n\n  Configuration path: [$arg] is not valid"
+            else
+              echo -ne "\n\n  Configuration path: $opath [$arg] is not valid"
+            fi
+            failed=true
+            break
           fi
-          get_help_text 0
-          echo -ne "$vyatta_help_text\n" | sed 's/^P/  P/'
-          failed=true
-          break
         else
-          if [[ $opath == '' ]]; then
-            echo -ne "\n\n  Configuration path: [$arg] is not valid"
-          else
-            echo -ne "\n\n  Configuration path: $opath [$arg] is not valid"
-          fi
-          failed=true
-          break
+          opath=$path
         fi
       else
-        opath=$path
+        if ! cli-shell-api validateTmplPath -- ${editlvl} ${path}; then
+          _cli_shell_api_comp_values=()
+          vyatta_cli_shell_api getCompletionEnv $cmd ${path}
+          if [[ "${#_cli_shell_api_comp_values[@]}" != "1"
+             && "${#_cli_shell_api_comp_values[@]}" != "0" ]]; then
+            local -a _get_help_text_items=( "${_cli_shell_api_hitems[@]}" )
+            local -a _get_help_text_helps=( "${_cli_shell_api_hstrs[@]}" )
+            local vyatta_help_text=''
+            if [[ $opath == '' ]]; then
+              echo -ne "\n\n  Configuration path: [$arg] is ambiguous\n"
+            else
+              echo -ne "\n\n  Configuration path: $opath [$arg] is ambiguous\n"
+            fi
+            get_help_text 0
+            echo -ne "$vyatta_help_text\n" | sed 's/^P/  P/'
+            failed=true
+            break
+          else
+            if [[ $opath == '' ]]; then
+              echo -ne "\n\n  Configuration path: [$arg] is not valid"
+            else
+              echo -ne "\n\n  Configuration path: $opath [$arg] is not valid"
+            fi
+            failed=true
+            break
+          fi
+        else
+          opath=$path
+        fi
       fi
     done
   fi
@@ -1009,7 +1053,11 @@ vyatta_config_complete ()
   # only do this for the second comp
   local nodeType="non-leaf"
   if [[ ${#api_args[@]} -gt 2 ]]; then
-    nodeType=$(cli-shell-api getNodeType ${editlvl} ${api_args[@]:1:$[${comp_cword}-1]})
+    if test -f "/var/run/vyconf_backend"; then
+      nodeType=$(${vyconf_bin_dir}/vyconf_cli_compat getNodeType ${editlvl} ${api_args[@]:1:$[${comp_cword}-1]})
+    else
+      nodeType=$(cli-shell-api getNodeType ${editlvl} ${api_args[@]:1:$[${comp_cword}-1]})
+    fi
   fi
 
   # Change the api arguments when we are dealing with a non last word
@@ -1024,12 +1072,22 @@ vyatta_config_complete ()
        api_args=( "${api_args[@]:0:$comp_cword}" "" )
      fi
   fi
-  if ! vyatta_cli_shell_api getCompletionEnv "${api_args[@]}"; then
-    # invalid completion
-    vyatta_config_invalid_comp "${expanded_api_args[@]}"
-    COMPREPLY=( "" " " )
-    eval $restore_shopts
-    return
+  if test -f "/var/run/vyconf_backend"; then
+    if ! vyos_cli_shell_api getCompletionEnv "${api_args[@]}"; then
+      # invalid completion
+      vyatta_config_invalid_comp "${expanded_api_args[@]}"
+      COMPREPLY=( "" " " )
+      eval $restore_shopts
+      return
+    fi
+  else
+    if ! vyatta_cli_shell_api getCompletionEnv "${api_args[@]}"; then
+      # invalid completion
+      vyatta_config_invalid_comp "${expanded_api_args[@]}"
+      COMPREPLY=( "" " " )
+      eval $restore_shopts
+      return
+    fi
   fi
   vyatta_cfg_comp_help=$_cli_shell_api_comp_help
   if [[ $exists_only == 1 ]] &&

--- a/functions/interpreter/vyatta-cfg-run
+++ b/functions/interpreter/vyatta-cfg-run
@@ -475,39 +475,70 @@ vyatta_cfg_validate_cmd ()
     local path=''
     local opath=''
     for arg in "${expanded_api_args[@]:1}"; do
-      if [[ "$path" == '' ]]; then 
+      if [[ "$path" == '' ]]; then
         path="$arg"
       else 
         path="$path $arg"
-      fi   
-      if ! cli-shell-api validateTmplPath -- ${editlvl} ${path}; then 
-        _cli_shell_api_comp_values=()
-        vyatta_cli_shell_api getCompletionEnv $cmd ${path} 
-        if [[ "${#_cli_shell_api_comp_values[@]}" != "1"  
-           && "${#_cli_shell_api_comp_values[@]}" != "0" ]]; then 
-          local -a _get_help_text_items=( "${_cli_shell_api_hitems[@]}" )
-          local -a _get_help_text_helps=( "${_cli_shell_api_hstrs[@]}" )
-          local vyatta_help_text=''
-          if [[ $opath == '' ]]; then 
-            echo -ne "\n  Configuration path: [$arg] is ambiguous\n" >&2
+      fi
+      if test -f "/var/run/vyconf_backend"; then
+        if ! ${vyconf_bin_dir}/vyconf_cli_compat validateTmplPath ${editlvl} ${path}; then
+          _cli_shell_api_comp_values=()
+          vyos_cli_shell_api getCompletionEnv $cmd ${path}
+          if [[ "${#_cli_shell_api_comp_values[@]}" != "1"
+             && "${#_cli_shell_api_comp_values[@]}" != "0" ]]; then
+            local -a _get_help_text_items=( "${_cli_shell_api_hitems[@]}" )
+            local -a _get_help_text_helps=( "${_cli_shell_api_hstrs[@]}" )
+            local vyatta_help_text=''
+            if [[ $opath == '' ]]; then
+              echo -ne "\n  Configuration path: [$arg] is ambiguous\n" >&2
+            else
+              echo -ne "\n  Configuration path: $opath [$arg] is ambiguous\n" >&2
+            fi
+            get_help_text
+            echo -e "$vyatta_help_text\n" | sed 's/^P/  P/'
+            echo -e "  ${cmd^} failed\n"
+            break
           else
-            echo -ne "\n  Configuration path: $opath [$arg] is ambiguous\n" >&2
+            if [[ $opath == '' ]]; then
+              echo -ne "\n  Configuration path: [$arg] is not valid\n  ${cmd^} failed\n\n" >&2
+            else
+              echo -ne "\n  Configuration path: $opath [$arg] is not valid\n  ${cmd^} failed\n\n" >&2
+            fi
+            break
           fi
-          get_help_text
-          echo -e "$vyatta_help_text\n" | sed 's/^P/  P/'
-          echo -e "  ${cmd^} failed\n"
-          break
         else
-          if [[ $opath == '' ]]; then 
-            echo -ne "\n  Configuration path: [$arg] is not valid\n  ${cmd^} failed\n\n" >&2
-          else
-            echo -ne "\n  Configuration path: $opath [$arg] is not valid\n  ${cmd^} failed\n\n" >&2
-          fi
-          break
+          opath=$path
         fi
-      else 
-        opath=$path
-      fi   
+      else
+        if ! cli-shell-api validateTmplPath -- ${editlvl} ${path}; then
+          _cli_shell_api_comp_values=()
+          vyatta_cli_shell_api getCompletionEnv $cmd ${path}
+          if [[ "${#_cli_shell_api_comp_values[@]}" != "1"
+             && "${#_cli_shell_api_comp_values[@]}" != "0" ]]; then
+            local -a _get_help_text_items=( "${_cli_shell_api_hitems[@]}" )
+            local -a _get_help_text_helps=( "${_cli_shell_api_hstrs[@]}" )
+            local vyatta_help_text=''
+            if [[ $opath == '' ]]; then
+              echo -ne "\n  Configuration path: [$arg] is ambiguous\n" >&2
+            else
+              echo -ne "\n  Configuration path: $opath [$arg] is ambiguous\n" >&2
+            fi
+            get_help_text
+            echo -e "$vyatta_help_text\n" | sed 's/^P/  P/'
+            echo -e "  ${cmd^} failed\n"
+            break
+          else
+            if [[ $opath == '' ]]; then
+              echo -ne "\n  Configuration path: [$arg] is not valid\n  ${cmd^} failed\n\n" >&2
+            else
+              echo -ne "\n  Configuration path: $opath [$arg] is not valid\n  ${cmd^} failed\n\n" >&2
+            fi
+            break
+          fi
+        else
+          opath=$path
+        fi
+      fi
     done 
 }
 
@@ -604,21 +635,40 @@ vyatta_cfg_cmd ()
     local editlvl=$(cli-shell-api getEditLevelStr)
   fi
   vyatta_config_expand_compwords "${args[@]}"
-  if [[ "${expanded_api_args[@]:$[${#expanded_api_args[@]}-1]}" == "-all" ]] &&
-     [[ "${expanded_api_args[0]}" == "show" ]]; then
-    if [[ $[${#expanded_api_args[@]}-2] -eq 0 ]]; then
-      vyatta_cfg_cmd_run "${expanded_api_args[@]}"
-    elif cli-shell-api validateTmplPath -- ${editlvl[*]} \
-         "${expanded_api_args[@]:1:$[${#expanded_api_args[@]}-2]}"; then
+  if test -f "/var/run/vyconf_backend"; then
+    if [[ "${expanded_api_args[@]:$[${#expanded_api_args[@]}-1]}" == "-all" ]] &&
+       [[ "${expanded_api_args[0]}" == "show" ]]; then
+      if [[ $[${#expanded_api_args[@]}-2] -eq 0 ]]; then
+        vyatta_cfg_cmd_run "${expanded_api_args[@]}"
+      elif ${vyconf_bin_dir}/vyconf_cli_compat validateTmplPath ${editlvl[*]} \
+           "${expanded_api_args[@]:1:$[${#expanded_api_args[@]}-2]}"; then
+        vyatta_cfg_cmd_run "${expanded_api_args[@]}"
+      else
+        vyatta_cfg_validate_cmd "${expanded_api_args[@]}"
+      fi
+    elif ${vyconf_bin_dir}/vyconf_cli_compat validateTmplPath ${editlvl[*]} "${expanded_api_args[@]:1}"; then
       vyatta_cfg_cmd_run "${expanded_api_args[@]}"
     else
+      # find broken portion of command
       vyatta_cfg_validate_cmd "${expanded_api_args[@]}"
     fi
-  elif cli-shell-api validateTmplPath -- ${editlvl[*]} "${expanded_api_args[@]:1}"; then
-    vyatta_cfg_cmd_run "${expanded_api_args[@]}"
   else
-    # find broken portion of command
-    vyatta_cfg_validate_cmd "${expanded_api_args[@]}"
+    if [[ "${expanded_api_args[@]:$[${#expanded_api_args[@]}-1]}" == "-all" ]] &&
+       [[ "${expanded_api_args[0]}" == "show" ]]; then
+      if [[ $[${#expanded_api_args[@]}-2] -eq 0 ]]; then
+        vyatta_cfg_cmd_run "${expanded_api_args[@]}"
+      elif cli-shell-api validateTmplPath -- ${editlvl[*]} \
+           "${expanded_api_args[@]:1:$[${#expanded_api_args[@]}-2]}"; then
+        vyatta_cfg_cmd_run "${expanded_api_args[@]}"
+      else
+        vyatta_cfg_validate_cmd "${expanded_api_args[@]}"
+      fi
+    elif cli-shell-api validateTmplPath -- ${editlvl[*]} "${expanded_api_args[@]:1}"; then
+      vyatta_cfg_cmd_run "${expanded_api_args[@]}"
+    else
+      # find broken portion of command
+      vyatta_cfg_validate_cmd "${expanded_api_args[@]}"
+    fi
   fi
 }
 ### Top level wrappers ###


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Use vyconf alternatives for validateTmplPath, getNodeType, getCompletionEnv in basic shell functions and completion. This allows correct completion on `set`/`delete`/`show` operations: note that the first requires only a generic mechanism, namely the reference tree, for correct completion of paths; however, for `delete` or `show` one wants to restrict to the existing config paths of the resident in memory proposed config, hence the need for simple requests to vyconfd.



## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [X] Other (please describe): integration of vyconf with shell internal functions and completion

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

https://github.com/vyos/vyos1x-config/pull/59
https://github.com/vyos/vyconf/pull/39

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```
vyos@vyos:~$ sudo /usr/libexec/vyos/set_vyconf_backend.py 
This will enable the vyconf backend for testing. Proceed? [y/N] y
vyos@vyos:~$ config
[edit]
vyos@vyos#

```

and then tab complete on either `delete` or `show` to see correct completion and help lists. Though an unassuming improvement on the face of it, this is implemented by a replacement for a critical feature of cli-shell-api, to wit, the misleadingly named, and overburdened, `get_parsed_tmpl` function.

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
