### PR TITLE
general: T8595: add CLAUDE.md

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,1 +1,0 @@
-CLAUDE.md

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../CLAUDE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,3 @@ Live consumer of the gen-1 PR mirror pipeline (`pr-mirror-repo-sync.yml`). Mirro
 - Treat as maintenance-only. New features go to `vyos-1x`. Touch this repo only for bug fixes on LTS trains or to keep templates compatible with current Debian.
 - The `pr-mirror-repo-sync.yml` workflow runs serially per merged PR; expect a downstream PR opened in `VyOS-Networks/vyatta-cfg` after merge. If `mirror-failed` label appears, see `vyos/.github` PRMirrorOnboarding.md.
 - Authoritative build set is `VyOS-Networks/vyos-build-packages/repos.toml`.
-
----
-
-This file is mirrored on Confluence: [`vyos/vyatta-cfg`](https://internal.confluence.vyos.com/wiki/spaces/VYOS/pages/817889665). The Confluence page also carries the per-repo audit data (settings, workflows, secret counts, hygiene) that complements this CLAUDE.md. Edit either side; resync via the documentation pipeline.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,45 @@
+# CLAUDE.md
+
+## Project purpose
+Legacy Vyatta configuration system: config back-end, base configuration templates, and config-mode CLI completion mechanism. Maintained for compatibility on VyOS LTS trains; new feature work goes into `vyos-1x` Python.
+
+## Tech stack
+- C/C++. Autotools build (`configure.ac`, `Makefile.am`).
+- Build deps (`debian/control`): `debhelper (>= 10)`, `libglib2.0-dev`, `libboost-filesystem-dev`, `libapt-pkg-dev`, `libtool`, `flex`, `bison`, `autoconf`, `automake`, `pkg-config`, `cpio`, `dh-autoreconf`.
+- Debian packaging via `dpkg-buildpackage`.
+
+## Build / test / run
+```
+autoreconf -i && ./configure && make
+# or, in tree:
+dpkg-buildpackage -uc -us -tc -b
+```
+No upstream test harness — validation happens at the integration level inside the live ISO build.
+
+## Repository layout
+- `src/`, `lib/`, `scripts/`, `functions/` — C/C++ sources, helper scripts, shell functions for the legacy CLI shell (`vbash`).
+- `etc/` — installed templates and skeleton config.
+- `debian/` — packaging.
+- `configure.ac`, `Makefile.am` — autotools.
+
+## Cross-repo context
+Pulled into ISO builds via `vyos/vyos-build` (listed in `VyOS-Networks/vyos-build-packages/repos.toml`). Pairs at runtime with `vyos/vyatta-bash` (the patched bash that hosts the CLI). Functionality has been progressively rewritten into `vyos/vyos-1x` (Python conf-mode/op-mode scripts) and `vyos/vyconf` (future OCaml session daemon).
+
+## Conventions
+- Commit/PR title: `component: T12345: description` (Phorge task ID at https://vyos.dev). Enforced by `vyos/.github/.github/workflows/check-pr-message.yml@current`.
+- Release-train branches: `current` (rolling), `circinus` (1.5 LTS), `sagitta` (1.4 LTS), `equuleus` (1.3 LTS).
+- Backports via `@Mergifyio backport <branch>` (Mergify built-in command).
+- Reusable workflows pinned to `vyos/.github/.github/workflows/<name>.yml@current` — changes ship immediately on merge.
+- Mergify config (single rule, adds `conflicts` label) lives in this repo.
+
+## Mirror relationship
+Live consumer of the gen-1 PR mirror pipeline (`pr-mirror-repo-sync.yml`). Mirror twin is `VyOS-Networks/vyatta-cfg` — only edit this canonical side; the mirror is force-pushed downstream automatically.
+
+## Notes for future contributors
+- Treat as maintenance-only. New features go to `vyos-1x`. Touch this repo only for bug fixes on LTS trains or to keep templates compatible with current Debian.
+- The `pr-mirror-repo-sync.yml` workflow runs serially per merged PR; expect a downstream PR opened in `VyOS-Networks/vyatta-cfg` after merge. If `mirror-failed` label appears, see `vyos/.github` PRMirrorOnboarding.md.
+- Authoritative build set is `VyOS-Networks/vyos-build-packages/repos.toml`.
+
+---
+
+This file is mirrored on Confluence: [`vyos/vyatta-cfg`](https://internal.confluence.vyos.com/wiki/spaces/VYOS/pages/817889665). The Confluence page also carries the per-repo audit data (settings, workflows, secret counts, hygiene) that complements this CLAUDE.md. Edit either side; resync via the documentation pipeline.


### PR DESCRIPTION
## Summary

Adds a single source of truth for repo-level agent instructions, plus three symlinks so different agentic tools all read the same content from one canonical file.

**Files added:**

| Path | Type | Consumed by |
|---|---|---|
| `CLAUDE.md` | real file | Claude Code, Anthropic agents |
| `AGENTS.md` | symlink → `CLAUDE.md` | tools that follow the AGENTS.md convention (e.g. OpenAI Codex) |
| `.cursorrules` | symlink → `CLAUDE.md` | Cursor |
| `.github/copilot-instructions.md` | symlink → `../CLAUDE.md` | GitHub Copilot ([docs](https://docs.github.com/en/copilot/how-tos/configure-custom-instructions-in-your-ide/add-repository-instructions-in-your-ide)) |

**Rationale**

- One source of truth — guidance lives in `CLAUDE.md`, the symlinks are zero-content. No drift between four files.
- Each agentic tool reads its canonical filename and gets the same content.
- Mac/Linux dev environments handle symlinks natively. Windows checkouts may render them as text files containing the target path; the canonical `CLAUDE.md` is unaffected and still rendered/served correctly by GitHub.

**Out of scope**

Path-specific Copilot instructions (`.github/instructions/*.instructions.md`) need YAML frontmatter (`applyTo:`) and target specific globs, so they cannot be symlinks. Not added here; they can be authored as separate small files per-repo if/when narrow path-scoped guidance is needed.

Tracked under [T8595](https://vyos.dev/T8595).

## Test plan

- [ ] `CLAUDE.md` renders on GitHub.
- [ ] `AGENTS.md`, `.cursorrules`, `.github/copilot-instructions.md` resolve to CLAUDE.md content (`readlink` returns the right target).
- [ ] CI passes.

🤖 Generated by [robots](https://vyos.io)
