### PR TITLE
chore: T8937: trivial change for Tier 1.2 verification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Legacy Vyatta configuration system: config back-end, base configuration template
 
 ## Build / test / run
 ```
-autoreconf -i &&./configure && make
+autoreconf -i && ./configure && make
 # or, in tree:
 dpkg-buildpackage -uc -us -tc -b
 ```


### PR DESCRIPTION
Verification followup for Tier 1.2 canary sweep ([vyos/vyatta-cfg#137](https://github.com/vyos/vyatta-cfg/pull/137)). Confirms central Mergify is the sole labeling/assigning actor on vyos/vyatta-cfg after the 5 GHA caller workflows were deleted.

**Change:** Fix missing space in `AGENTS.md` build command: `` autoreconf -i &&./configure `` → `` autoreconf -i && ./configure ``.

Advances: T8937

🤖 Generated by [robots](https://vyos.io)