### PR TITLE
T8943: migrate branch refs current->rolling (rollout 1c)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,7 +3,7 @@ name: "Perform CodeQL Analysis"
 on:
   push:
     branches: 
-      - current
+      - rolling
       - circinus
       - sagitta
     paths:
@@ -13,7 +13,7 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: 
-      - current
+      - rolling
       - circinus
       - sagitta
     paths:

--- a/.github/workflows/lint-j2.yml
+++ b/.github/workflows/lint-j2.yml
@@ -2,7 +2,7 @@ name: Lint J2
 on:
   pull_request_target:
     branches:
-      - current
+      - rolling
       - circinus
       - sagitta
 

--- a/.github/workflows/pr-mirror-repo-sync.yml
+++ b/.github/workflows/pr-mirror-repo-sync.yml
@@ -6,7 +6,7 @@ name: PR Mirror and Repo Sync
 on:
   pull_request_target:
     types: [closed]
-    branches: [current]
+    branches: [rolling]
   workflow_dispatch:
     inputs:
       sync_branch:

--- a/.github/workflows/trigger-rebuild-repo-package.yml
+++ b/.github/workflows/trigger-rebuild-repo-package.yml
@@ -5,7 +5,7 @@ on:
     types:
       - closed
     branches:
-      - current
+      - rolling
       - circinus
       - sagitta
   workflow_dispatch:


### PR DESCRIPTION
Rollout 1c reference migration. Own trunk refs current->rolling; action-ref to vyos/.github -> production; HIGH-producer pins already swept. Tracking: T8943