### PR TITLE
ci: T8966: exempt bots from product T-ID (invalid-task-id) gate

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -37,6 +37,9 @@ pull_request_rules:
     conditions:
       - '-closed'
       - '-merged'
+      - '-author~=\[bot\]$'
+      - 'author!=copilot-swe-agent'
+      - 'author!=vyosbot'
       - or:
           - '-title~=^(([a-zA-Z0-9\-_.]+:\s)?)T\d+:\s+[^\s]+.*'
           - 'commits[*].commit_message~=^(?!(([a-zA-Z0-9\-_.]+:\s)?)T\d+:\s+[^\s]+).*'


### PR DESCRIPTION
Adds the blessed 3-condition bot exclusion to this repo's product T-ID rule so bot PRs aren't gated by the T-ID convention, per T8966. Uniform across all product repos.

🤖 Generated by [robots](https://vyos.io)