### PR TITLE
ci: T9047: grant issues: write to stale workflow token

### DIFF
--- a/.github/workflows/check-stale.yml
+++ b/.github/workflows/check-stale.yml
@@ -4,6 +4,7 @@ on:
   - cron: "0 0 * * *"
 
 permissions:
+  issues: write
   pull-requests: write
   contents: read
 


### PR DESCRIPTION
Adds `issues: write` to the explicit permissions block of the stale workflow caller.

The block currently grants only `pull-requests: write` + `contents: read`; `actions/stale@v10`'s
issue pass fails on VyOS-Networks twins with "Getting issues was blocked by the error: Resource
not accessible by integration" (100% of scheduled runs). The vyos-side run is unaffected. The
mirror propagates this fix to the VN twin.

Advances: IS-574

🤖 Generated by [robots](https://vyos.io)