### PR TITLE
ci: T9047: skip CodeQL on mirror twins (Code Security not enabled on private org)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,6 +30,7 @@ permissions:
 
 jobs:
   codeql-analysis-call:
+    if: github.repository_owner == 'vyos'
     uses: vyos/.github/.github/workflows/codeql-analysis.yml@production
     secrets: inherit
     with:


### PR DESCRIPTION
Adds `if: github.repository_owner == 'vyos'` to the CodeQL job in this workflow.

This workflow mirrors to the private `VyOS-Networks` twin, where Code Security /
GitHub Advanced Security is not enabled. Every scheduled and push-triggered CodeQL run on the
mirror twin fails outright (100% failure rate) — CodeQL requires an enabled Code Security
license on the repository it runs against, which the private org does not have.

The guard makes the job a no-op (skipped, green) on the mirror twin while leaving CodeQL
scanning fully unaffected on this repo (`github.repository_owner == 'vyos'` evaluates true
here). This matches the existing pattern already used to keep mirror-stub repos inert where a
capability genuinely cannot run.

Advances: IS-574

🤖 Generated by [robots](https://vyos.io)
