### PR TITLE
T9144: add no-prompt option to commit-confirm

### DIFF
--- a/etc/bash_completion.d/vyatta-cfg
+++ b/etc/bash_completion.d/vyatta-cfg
@@ -432,6 +432,7 @@ vyatta_commit_complete ()
       elif [ "${COMP_WORDS[0]}" = "commit-confirm" ]; then
          echo -e "  <Enter>\tCommit, revert commit in 10 minutes if no confirm"
          echo -e "  <N>\t\tCommit, revert commit in N minutes if no confirm"
+         echo -e "  no-prompt\tDo not prompt for execution"
       fi
       echo -e "  comment\tComment for commit log"
       COMPREPLY=( "" " " )

--- a/functions/interpreter/vyatta-cfg-run
+++ b/functions/interpreter/vyatta-cfg-run
@@ -163,7 +163,16 @@ vyatta_config_commit-confirm ()
   local -a args=()
   local first=1
   local minutes=10
+  local yes_flag=""
+  local in_comment=0
   for arg in "$@"; do
+    if [ "$arg" = "no-prompt" ] && [ "$in_comment" = "0" ]; then
+      yes_flag="-y"
+      continue
+    fi
+    if [ "$arg" = "comment" ]; then
+      in_comment=1
+    fi
     if [ "$first" = "1" ]; then
       if [[ $arg = *[[:digit:]]* ]]; then
         minutes=$arg
@@ -175,7 +184,7 @@ vyatta_config_commit-confirm ()
       args[${#args[@]}]="$arg"    
     fi
   done
-  cmd="${vyos_bin_dir}/config-mgmt commit_confirm -t=$minutes"
+  cmd="${vyos_bin_dir}/config-mgmt commit_confirm -t=$minutes $yes_flag"
   eval "sudo sg vyattacfg \"$cmd\" "
   if [ $? = 0 ]; then
     export IN_COMMIT_CONFIRM=t


### PR DESCRIPTION
`commit-confirm` always prompts for confirmation before executing, which makes it unusable from scripts: when stdin is not a terminal the prompt cannot be answered (T9144). This adds an explicit `no-prompt` option to the configure-mode wrapper, forwarded to `config-mgmt commit_confirm` as its existing `-y` (`no_prompt`) parameter.

- `commit-confirm no-prompt` and `commit-confirm <minutes> no-prompt` skip the proceed prompt; the commit still reverts unless confirmed within the window.
- The option appears in tab completion help.
- `no-prompt` is only recognized before the `comment` keyword, so a comment containing the literal word is passed through unchanged.

Incorporates the modification suggested by @jestabro in review.