### PR TITLE
T9164: accept NOS-/VD- Jira keys in task-id check; pin NOS in coderabbit

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -26,4 +26,5 @@ knowledge_base:
     # source where it is not.
     usage: auto
     project_keys:
+      - NOS
       - VD

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -30,10 +30,12 @@ pull_request_rules:
   - name: Flag product T-ID format violation in PR title or commit messages
     description: >
       Product-repo convention: PR title and every commit's first line must
-      match `T<digits>: <text>` (optional `scope: ` prefix). Relocated from
-      the central config (T8966) so the T-ID convention is opt-in per product
-      repo. Name is intentionally distinct from any central rule name so this
-      stays additive (not an `extends:` override).
+      match a `T<digits>:`, `NOS-<digits>:` or legacy `VD-<digits>:` task key
+      followed by text (optional `scope: ` prefix). NOS is the renamed VD Jira
+      project (2026-07). Relocated from the central config (T8966) so the T-ID
+      convention is opt-in per product repo. Name is intentionally distinct
+      from any central rule name so this stays additive (not an `extends:`
+      override).
     conditions:
       - '-closed'
       - '-merged'
@@ -41,10 +43,10 @@ pull_request_rules:
       - 'author!=copilot-swe-agent'
       - 'author!=vyosbot'
       - or:
-          - '-title~=^(([a-zA-Z0-9\-_.]+:\s)?)T\d+:\s+[^\s]+.*'
+          - '-title~=^(([a-zA-Z0-9\-_.]+:[ ])?)(T[0-9]+|NOS-[0-9]+|VD-[0-9]+):[ ]+[^\s]+.*'
           - and:
               - 'label!=legacy'
-              - 'commits[*].commit_message~=^(?!(([a-zA-Z0-9\-_.]+:\s)?)T\d+:\s+[^\s]+).*'
+              - 'commits[*].commit_message~=^(?!(([a-zA-Z0-9\-_.]+:[ ])?)(T[0-9]+|NOS-[0-9]+|VD-[0-9]+):[ ]+[^\s]+).*'
     actions:
       label:
         toggle:


### PR DESCRIPTION
Fleet replication of the adversarially-reviewed canary [vyos/vyos-1x#5379](https://github.com/vyos/vyos-1x/pull/5379) for the VD→NOS Jira project rename ([T9164](https://vyos.dev/T9164)). `.github/mergify.yml` — the `invalid-task-id` rule's two regexes and its `description` now accept `T<digits>:`, `NOS-<digits>:` and legacy `VD-<digits>:` keys; the rule **name** is byte-identical, so this stays additive rather than an `extends:` override. `.coderabbit.yaml` — `knowledge_base.jira.project_keys` pins `NOS` ahead of the retained legacy `VD`. Byte-identical template application — `skip-adversarial` per the documented escape hatch (2 findings were found and fixed on the canary; regexes ship tightened: ASCII digits + literal-space separators).

Phase 0 (local CodeRabbit CLI, `--base origin/rolling`): clean — 0 findings.

Advances: IS-640

🤖 Generated by [robots](https://vyos.io)

